### PR TITLE
Only run CI push on main

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,6 +2,7 @@ name: Java CI with Gradle
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
There are duplicate runs of CI when a PR is opened. One is from the `pull_request` tag and the other is from the `push` tag. We should only run CI via push when the branch is `main`. Otherwise, we should only run when a pull request is made. Note that this means CI won't run on branches that are *not* yet PRs but I'm pretty sure no one checks that in that case. Plus, it only matters when in PR.