### PR TITLE
Enable `AvoidLiteralsInIfCondition` PMD rule

### DIFF
--- a/sciborgs1155-pmd-ruleset.xml
+++ b/sciborgs1155-pmd-ruleset.xml
@@ -76,8 +76,7 @@
 
 
   <rule ref="category/java/documentation.xml">
-    <exclude name="CommentRequired" /> <!-- Currently, our style doesn't require JavaDoc but we should. Let's enable
-      this later. -->
+    <exclude name="CommentRequired" /> <!-- Defined and configured above, so we should not duplicate it here. -->
     <exclude name="CommentSize" /> <!-- I'm fine with long comments as long as they maintain good information. -->
     <exclude name="UncommentedEmptyConstructor" /> <!-- Not necessary -->
     <exclude name="UncommentedEmptyMethodBody" /> <!-- Not necessary -->
@@ -86,7 +85,6 @@
   <rule ref="category/java/errorprone.xml">
     <exclude name="AvoidCatchingGenericException" /> <!-- Used a lot in lock context. I'll stay far away -->
     <exclude name="AvoidFieldNameMatchingMethodName" /> <!-- Violated often -->
-    <exclude name="AvoidLiteralsInIfCondition" /> <!-- I personally think this is fine and readable -->
     <exclude name="CloseResource" /> <!-- Many violations exist currently. We may want to do something about this
       to prevent resource leaks. -->
     <exclude name="ConstructorCallsOverridableMethod" /> <!-- This is used often in subsystem construction -->

--- a/src/main/java/org/sciborgs1155/lib/RepulsorFieldPlanner.java
+++ b/src/main/java/org/sciborgs1155/lib/RepulsorFieldPlanner.java
@@ -72,6 +72,7 @@ public class RepulsorFieldPlanner {
   static class PointObstacle extends Obstacle {
     Translation2d loc;
     double radius = 0.5;
+    static final int MAX_DIST = 4;
 
     /**
      * Creates a new point obstacle.
@@ -89,7 +90,7 @@ public class RepulsorFieldPlanner {
     public Force getForceAtPosition(Translation2d position, Translation2d target) {
       // displacement from obstacle
       double dist = loc.getDistance(position);
-      if (dist > 4) {
+      if (dist > MAX_DIST) {
         return new Force();
       }
       // distance from the position to the outer radius of the target.

--- a/src/main/java/org/sciborgs1155/robot/vision/Vision.java
+++ b/src/main/java/org/sciborgs1155/robot/vision/Vision.java
@@ -271,6 +271,7 @@ public class Vision {
    *
    * @param estimatedPose The estimated pose to guess standard deviations for.
    */
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   public Matrix<N3, N1> estimationStdDevs(
       Pose2d estimatedPose, PhotonPipelineResult pipelineResult) {
     var estStdDevs = SINGLE_TAG_STD_DEVS;


### PR DESCRIPTION
This PR enables the [AvoidLiteralsInIfCondition](https://docs.pmd-code.org/latest/pmd_rules_java_errorprone.html#avoidliteralsinifcondition) PMD rule.