### PR TITLE
Create git pre-commit hook to automatically run Spotless before every commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,19 @@ deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
 
+// Task for installing the git pre-commit hook for automatically running Spotless
+tasks.register('installGitHooks', Copy) {
+    from('scripts/pre-commit.sh')
+    into('.git/hooks')
+    rename('pre-commit.sh', 'pre-commit')
+    fileMode = 0755 // Executable file
+    group = "git"
+    description = "Installs the git pre-commit hook."
+}
+
+// Install git hooks before build
+tasks.build.dependsOn installGitHooks
+
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "Running Spotless pre-commit hook..."
+# This script runs spotlessApply before committing.
+./gradlew spotlessApply -q
+# Add any changes made by spotlessApply to the commit.
+git add -u


### PR DESCRIPTION
I see a lot of commits on PRs failing the Spotless check when it's easily fixed by running the `spotlessApply` Gradle task. This PR adds a git pre-commit hook that runs `spotlessApply` before every commit.